### PR TITLE
Bundle size reduction

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,12 +5,12 @@
   "dependencies": {
     "@types/gl-matrix": "^2.4.5",
     "@types/jest": "^24.0.22",
-    "@types/lodash": "^4.14.146",
     "@types/node": "^12.12.6",
     "@types/react": "^16.9.11",
     "@types/react-dom": "^16.9.4",
+    "cra-preact": "^0.4.0",
     "gl-matrix": "^3.1.0",
-    "pepjs": "^0.5.2",
+    "preact-render-to-string": "^5.1.21",
     "promptpay-qr": "^0.4.4",
     "qrcode": "0.9.0",
     "react": "^18.0.0",
@@ -21,9 +21,9 @@
     "typescript": "^3.7.2"
   },
   "scripts": {
-    "start": "react-scripts start",
+    "start": "cra-preact start",
     "start-server": "env PORT=3000 http-server build",
-    "build": "react-scripts build",
+    "build": "cra-preact build",
     "test": "playwright test",
     "eject": "react-scripts eject"
   },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,13 +2,10 @@ import React, { Component, useState, useEffect } from 'react'
 
 import Flipper from './Flipper'
 import SlotSelector from './SlotSelector'
-import _ from 'lodash'
 import generatePayload from 'promptpay-qr'
 import QRCode from './QRCode'
 import { t, LocalizationProvider } from './Localization'
 import AppHeader from './AppHeader'
-
-// import { Button } from 'reakit/Button'
 
 const ver = require('promptpay-qr/package.json').version
 
@@ -60,9 +57,13 @@ class AppMain extends Component {
   state = this.getInitialState()
   getInitialState() {
     const slotNumber = +window.localStorage.promptPayActiveSlot || 1
-    const data = _.mapValues(storageKeys, (storageKey) =>
-      sanitizeId(window.localStorage[storageKey] || ''),
+    const data = Object.fromEntries(
+      Object.entries(storageKeys).map(([index, storageKey]) => [
+        index,
+        sanitizeId(window.localStorage[storageKey] || ''),
+      ]),
     )
+
     return {
       data: data,
       slotNumber: slotNumber as 1 | 2 | 3 | 4,

--- a/src/SlotSelector.js
+++ b/src/SlotSelector.js
@@ -1,5 +1,3 @@
-import React from 'react'
-import _ from 'lodash'
 import './SlotSelector.css'
 
 export function SlotSelector(props) {
@@ -16,7 +14,7 @@ export function SlotSelector(props) {
           >
             <span className="SlotSelectorのnum">{i}</span>
             <span className="SlotSelectorのinfo">
-              {renderInfo(_.get(props.data, [i]))}
+              {renderInfo(props.data[i])}
             </span>
           </button>
         )

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,4 @@
 import './index.css'
-import 'pepjs'
 
 import App from './App'
 import React from 'react'

--- a/yarn.lock
+++ b/yarn.lock
@@ -1876,11 +1876,6 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
-"@types/lodash@^4.14.146":
-  version "4.14.181"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.181.tgz#d1d3740c379fda17ab175165ba04e2d03389385d"
-  integrity sha512-n3tyKthHJbkiWhDZs3DkhkCzt2MexYHXlX0td5iMplyfwketaOeKboEVBqzceH7juqvEg3q5oUoBFxSLu7zFag==
-
 "@types/mime@^1":
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-1.3.2.tgz#93e25bf9ee75fe0fd80b594bc4feb0e862111b5a"
@@ -2956,9 +2951,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001317:
-  version "1.0.30001328"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001328.tgz#0ed7a2ca65ec45872c613630201644237ba1e329"
-  integrity sha512-Ue55jHkR/s4r00FLNiX+hGMMuwml/QGqqzVeMQ5thUewznU2EdULFvI3JR7JJid6OrjJNfFvHY2G2dIjmRaDDQ==
+  version "1.0.30001332"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001332.tgz"
+  integrity sha512-10T30NYOEQtN6C11YGg411yebhvpnC6Z102+B95eAsN0oB6KUs01ivE8u+G6FMIRtIrVlYXhL+LUwQ3/hXwDWw==
 
 case-sensitive-paths-webpack-plugin@^2.4.0:
   version "2.4.0"
@@ -3286,6 +3281,14 @@ cosmiconfig@^7.0.0:
     parse-json "^5.0.0"
     path-type "^4.0.0"
     yaml "^1.10.0"
+
+cra-preact@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/cra-preact/-/cra-preact-0.4.0.tgz#73fd864e7a480405bf62d11522d336b5d0e7a278"
+  integrity sha512-kiRkKqPmFbw/Bwg6F/gt5eWdPqFqeUj5y0pAdDMuC0jztclzyuqGJu727lsJDdCpBaJO82Z8flQj4VqRjmtQXQ==
+  dependencies:
+    preact "^10.3.2"
+    require-in-the-middle "^5.0.3"
 
 crc@^3.4.4:
   version "3.8.0"
@@ -6493,6 +6496,11 @@ mkdirp@^0.5.1, mkdirp@^0.5.5, mkdirp@~0.5.1:
   dependencies:
     minimist "^1.2.6"
 
+module-details-from-path@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/module-details-from-path/-/module-details-from-path-1.0.3.tgz#114c949673e2a8a35e9d35788527aa37b679da2b"
+  integrity sha1-EUyUlnPiqKNenTV4hSeqN7Z52is=
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
@@ -6947,11 +6955,6 @@ pend@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
   integrity sha1-elfrVQpng/kRUzH89GY9XI4AelA=
-
-pepjs@^0.5.2:
-  version "0.5.3"
-  resolved "https://registry.yarnpkg.com/pepjs/-/pepjs-0.5.3.tgz#dc755f03d965c20e4b1bb65e42a03a97c382cfc7"
-  integrity sha512-5yHVB9OHqKd9fr/OIsn8ss0NgThQ9buaqrEuwr9Or5YjPp6h+WTDKWZI+xZLaBGZCtODTnFtlSHNmhFsq67THg==
 
 performance-now@^2.1.0:
   version "2.1.0"
@@ -7583,6 +7586,18 @@ postcss@^8.3.5, postcss@^8.4.12, postcss@^8.4.4, postcss@^8.4.7:
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
 
+preact-render-to-string@^5.1.21:
+  version "5.1.21"
+  resolved "https://registry.yarnpkg.com/preact-render-to-string/-/preact-render-to-string-5.1.21.tgz#7329a59191d2ca7a40635828c7058f64ffe17639"
+  integrity sha512-wbMtNU4JpfvbE04iCe7BZ1yLYN8i6NRrq+NhR0fUINjPXGu3ZIc4GM5ScOiwdIP1sPXv9SVETuud/tmQGMvdNQ==
+  dependencies:
+    pretty-format "^3.8.0"
+
+preact@^10.3.2:
+  version "10.7.1"
+  resolved "https://registry.yarnpkg.com/preact/-/preact-10.7.1.tgz#bdd2b2dce91a5842c3b9b34dfe050e5401068c9e"
+  integrity sha512-MufnRFz39aIhs9AMFisonjzTud1PK1bY+jcJLo6m2T9Uh8AqjD77w11eAAawmjUogoGOnipECq7e/1RClIKsxg==
+
 prelude-ls@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
@@ -7629,6 +7644,11 @@ pretty-format@^27.2.5, pretty-format@^27.5.1:
     ansi-regex "^5.0.1"
     ansi-styles "^5.0.0"
     react-is "^17.0.1"
+
+pretty-format@^3.8.0:
+  version "3.8.0"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-3.8.0.tgz#bfbed56d5e9a776645f4b1ff7aa1a3ac4fa3c385"
+  integrity sha1-v77VbV6ad2ZF9LH/eqGjrE+jw4U=
 
 process-nextick-args@~2.0.0:
   version "2.0.1"
@@ -8151,6 +8171,15 @@ require-from-string@^2.0.2:
   resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
   integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
 
+require-in-the-middle@^5.0.3:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/require-in-the-middle/-/require-in-the-middle-5.1.0.tgz#b768f800377b47526d026bbf5a7f727f16eb412f"
+  integrity sha512-M2rLKVupQfJ5lf9OvqFGIT+9iVLnTmjgbOmpil12hiSQNn5zJTKGPoIisETNjfK+09vP3rpm1zJajmErpr2sEQ==
+  dependencies:
+    debug "^4.1.1"
+    module-details-from-path "^1.0.3"
+    resolve "^1.12.0"
+
 requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
@@ -8189,7 +8218,7 @@ resolve.exports@^1.1.0:
   resolved "https://registry.yarnpkg.com/resolve.exports/-/resolve.exports-1.1.0.tgz#5ce842b94b05146c0e03076985d1d0e7e48c90c9"
   integrity sha512-J1l+Zxxp4XK3LUDZ9m60LRJF/mAe4z6a4xyabPHk7pvK5t35dACV32iIjJDFeWZFfZlO29w6SZ67knR0tHzJtQ==
 
-resolve@^1.14.2, resolve@^1.19.0, resolve@^1.20.0, resolve@^1.22.0:
+resolve@^1.12.0, resolve@^1.14.2, resolve@^1.19.0, resolve@^1.20.0, resolve@^1.22.0:
   version "1.22.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.0.tgz#5e0b8c67c15df57a89bdbabe603a002f21731198"
   integrity sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==


### PR DESCRIPTION
- `cra-preact` alias `preact` as render engine
- remove pointer events polyfill since it already supported by 91.68% of users already
- remove unnecessary `lodash` imports

**Before:** 124.43 kB
**After:** 42.68 kB